### PR TITLE
fix: handle JSON.parse exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,22 @@ module.exports = [
 ];
 ```
 
+Add this field to any desired content-type attributes
+
+```json5
+{
+    // ...
+    "attributes": {
+        // ...
+        "video": {
+            "type": "customField",
+            "customField": "plugin::video-field.video",
+        }
+        // ...
+    }
+}
+```
+
 Then run build:
 
 ```bash

--- a/admin/src/components/VideoField/VideoInput/index.js
+++ b/admin/src/components/VideoField/VideoInput/index.js
@@ -30,7 +30,11 @@ const VideoInput = ({
 
     // Load data from value on page load
     useEffect(() => {
-        const initialValue = JSON.parse(value);
+        const initialValue = {};
+        try {
+            initialValue = JSON.parse(value);
+        } catch (e) { }
+
         if (initialValue?.url) {
             setVideoUrl(initialValue.url);
             if (initialValue.provider && initialValue.providerUid) {


### PR DESCRIPTION
With the last version of Strapi, the default value is missing, and trying to parse it will throw an exception.