### PR TITLE
Fix vimeo video provider UID and privacy hash extraction

### DIFF
--- a/admin/src/utils/getVideoProviderAndUid.ts
+++ b/admin/src/utils/getVideoProviderAndUid.ts
@@ -3,7 +3,7 @@ const getVideoProviderAndUid = (url: string) => {
     const regExp =
       /^https?:\/\/(?:www\.)?vimeo\.com\/(?:(?:channels\/[\w]+\/)|(groups\/[\w]+\/videos\/))?(\d+)(?:\/([\w]+))?/;
     const match = url.match(regExp);
-    if (match && match[1]) {
+    if (match && match[2]) {
       return {
         provider: "vimeo",
         providerUid: match[2],

--- a/admin/src/utils/getVideoProviderAndUid.ts
+++ b/admin/src/utils/getVideoProviderAndUid.ts
@@ -6,8 +6,8 @@ const getVideoProviderAndUid = (url: string) => {
     if (match && match[1]) {
       return {
         provider: "vimeo",
-        providerUid: match[1],
-        privacyHash: match[2] || null,
+        providerUid: match[2],
+        privacyHash: match[3] || null,
       };
     }
   }


### PR DESCRIPTION
Currently, the video input field will always show an error message that the video url is invalid in case of vimeo urls. This is because the regex groups are wrong. I'm not an expert regarding regex, so I just switched to the correct match index.